### PR TITLE
Add functionality to store Football Leagues from external api

### DIFF
--- a/FOOTBALL-API RESPONSES/FOOTBALL-LEAGES.json
+++ b/FOOTBALL-API RESPONSES/FOOTBALL-LEAGES.json
@@ -1,0 +1,220 @@
+{
+  get: "leagues",
+  parameters: [
+  ],
+  errors: [
+  ],
+  results: 1190,
+  paging: {
+    current: 1
+    total: 1
+  }
+  response: [
+    {
+      league: {
+        id: 4
+        name: "Euro Championship"
+        type: "Cup"
+        logo: "https://media.api-sports.io/football/leagues/4.png"
+      }
+      country: {
+        name: "World"
+        code: null
+        flag: null
+      }
+      seasons: [
+        {
+          year: 2008
+          start: "2008-06-07"
+          end: "2008-06-29"
+          current: false
+          coverage: {
+            fixtures: {
+              events: true
+              lineups: true
+              statistics_fixtures: false
+              statistics_players: false
+            }
+            standings: false
+            players: true
+            top_scorers: true
+            top_assists: true
+            top_cards: true
+            injuries: false
+            predictions: true
+            odds: false
+          }
+        }
+        {
+          year: 2012
+          start: "2012-06-08"
+          end: "2012-07-01"
+          current: false
+          coverage: {
+            fixtures: {
+              events: true
+              lineups: true
+              statistics_fixtures: false
+              statistics_players: false
+            }
+            standings: false
+            players: true
+            top_scorers: true
+            top_assists: true
+            top_cards: true
+            injuries: false
+            predictions: true
+            odds: false
+          }
+        }
+        {
+          year: 2016
+          start: "2016-06-10"
+          end: "2016-07-10"
+          current: false
+          coverage: {
+            fixtures: {
+              events: true
+              lineups: true
+              statistics_fixtures: true
+              statistics_players: true
+            }
+            standings: true
+            players: true
+            top_scorers: true
+            top_assists: true
+            top_cards: true
+            injuries: false
+            predictions: true
+            odds: false
+          }
+        }
+        {
+          year: 2020
+          start: "2019-03-21"
+          end: "2021-07-11"
+          current: false
+          coverage: {
+            fixtures: {
+              events: true
+              lineups: true
+              statistics_fixtures: true
+              statistics_players: true
+            }
+            standings: true
+            players: true
+            top_scorers: true
+            top_assists: true
+            top_cards: true
+            injuries: false
+            predictions: true
+            odds: false
+          }
+        }
+        {
+          year: 2024
+          start: "2024-06-14"
+          end: "2024-07-14"
+          current: true
+          coverage: {
+            fixtures: {
+              events: true
+              lineups: true
+              statistics_fixtures: true
+              statistics_players: true
+            }
+            standings: true
+            players: true
+            top_scorers: true
+            top_assists: true
+            top_cards: true
+            injuries: false
+            predictions: true
+            odds: false
+          }
+        }
+      ]
+    }
+    {
+      league: {
+        id: 21
+        name: "Confederations Cup"
+        type: "Cup"
+        logo: "https://media.api-sports.io/football/leagues/21.png"
+      }
+      country: {
+        name: "World"
+        code: null
+        flag: null
+      }
+      seasons: [
+        {
+          year: 2009
+          start: "2009-06-14"
+          end: "2009-06-28"
+          current: false
+          coverage: {
+            fixtures: {
+              events: true
+              lineups: true
+              statistics_fixtures: false
+              statistics_players: false
+            }
+            standings: false
+            players: true
+            top_scorers: true
+            top_assists: true
+            top_cards: true
+            injuries: false
+            predictions: true
+            odds: false
+          }
+        }
+        {
+          year: 2013
+          start: "2013-06-15"
+          end: "2013-06-30"
+          current: false
+          coverage: {
+            fixtures: {
+              events: true
+              lineups: true
+              statistics_fixtures: false
+              statistics_players: false
+            }
+            standings: false
+            players: true
+            top_scorers: true
+            top_assists: true
+            top_cards: true
+            injuries: false
+            predictions: true
+            odds: false
+          }
+        }
+        {
+          year: 2017
+          start: "2017-06-17"
+          end: "2017-07-02"
+          current: true
+          coverage: {
+            fixtures: {
+              events: true
+              lineups: true
+              statistics_fixtures: true
+              statistics_players: false
+            }
+            standings: false
+            players: true
+            top_scorers: true
+            top_assists: true
+            top_cards: true
+            injuries: false
+            predictions: true
+            odds: false
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/app/Commands/StoreFootballLeagues.php
+++ b/app/Commands/StoreFootballLeagues.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace App\Commands;
+
+use CodeIgniter\CLI\BaseCommand;
+use CodeIgniter\CLI\CLI;
+use App\Services\FootballService;
+use App\Models\FootballLeagues;
+
+class StoreFootballLeagues extends BaseCommand
+{
+    /**
+     * The Command's Group
+     *
+     * @var string
+     */
+    protected $group = 'App';
+
+    /**
+     * The Command's Name
+     *
+     * @var string
+     */
+    protected $name = 'app:store_football_leagues';
+
+    /**
+     * The Command's Description
+     *
+     * @var string
+     */
+    protected $description = 'This command stores football leagues in the database.';
+
+    /**
+     * The Command's Usage
+     *
+     * @var string
+     */
+    protected $usage = 'app:store_football_leagues';
+
+    /**
+     * The Command's Arguments
+     *
+     * @var array
+     */
+    protected $arguments = [];
+
+    /**
+     * The Command's Options
+     *
+     * @var array
+     */
+    protected $options = [];
+    
+    protected FootballService $service;
+
+    public function __construct()
+    {
+
+        $this->service = new FootballService();
+        $this->leagueModel = new \App\Models\FootballLeagues();
+    }
+
+    /**
+     * Actually execute a command.
+     *
+     * @param array $params
+     */
+    public function run(array $params)
+    {
+        $apiLeagues = $this->service->listLeagues() ?? [];
+
+        //$FootballLeagueModel = new \App\Models\FootballLeagues();
+        foreach ($apiLeagues as $item) {
+            $leagueId = $item['league']['id'];
+
+            // Check if the league already exists
+            $existing = $this->leagueModel->where('id', $leagueId)->first();
+
+            if ($existing) {
+                // League exists, skip to next iteration
+                continue;
+            }
+
+
+                $leagueData = [
+                    'id' => $item['league']['id'],
+                    'name' => $item['league']['name'],
+                    'type' => $item['league']['type'],
+                    // Add other fields as needed, matching your table's columns
+                ];
+
+
+                try {
+                    $this->leagueModel->insert($leagueData);
+                } catch (\Exception $e) {
+                    echo '<br> Error Here' .$e->getMessage();
+                }
+
+                echo "Leagues stored successfully.";
+            }
+    }
+}

--- a/app/Config/Routes.php
+++ b/app/Config/Routes.php
@@ -44,3 +44,6 @@ $routes->post('cache-test/store', [CacheTest::class, 'store']);
 // Route for showing a single product.
 // Maps a GET request to 'cachetest/show/123' to the 'show' method.
 $routes->get('cache-test/show/(:num)', [CacheTest::class, 'show']);
+
+//Football Routes
+$routes->get('football/leagues', 'FootballController::leagues');

--- a/app/Controllers/FootballController.php
+++ b/app/Controllers/FootballController.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Controllers;
+
+use App\Controllers\BaseController;
+use CodeIgniter\HTTP\ResponseInterface;
+use App\Services\FootballService;
+use CodeIgniter\RESTful\ResourceController;
+
+class FootballController extends ResourceController
+{
+    protected FootballService $service;
+
+    public function __construct()
+    {
+        $this->service = new FootballService();
+    }
+
+    public function leagues()
+    {
+        return $this->respond($this->service->listLeagues());
+    }
+}

--- a/app/Database/Migrations/2025-08-28-215556_CreateFootballLeaguesTable.php
+++ b/app/Database/Migrations/2025-08-28-215556_CreateFootballLeaguesTable.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Database\Migrations;
+
+use CodeIgniter\Database\Migration;
+
+class CreateFootballLeaguesTable extends Migration
+{
+    public function up()
+    {
+        $this->forge->addField([
+                'id' => ['type' => 'INT',
+                'unsigned' => true,
+            ],
+                'name' => ['type' => 'VARCHAR',
+                'constraint' => '255',
+            ],
+                'type' => ['type' => 'VARCHAR',
+                'constraint' => '64',
+            ],
+            'created_at' => [
+                'type' => 'DATETIME',
+                'null' => true,
+            ],
+            'updated_at' => [
+                'type' => 'DATETIME',
+                'null' => true,
+            ],
+        ]);
+
+        $this->forge->addKey('id', true);
+        $this->forge->createTable('football_leagues');
+    }
+
+    public function down()
+    {
+        $this->forge->dropTable('football_leagues');
+    }
+}

--- a/app/Models/FootballLeagues.php
+++ b/app/Models/FootballLeagues.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Models;
+
+use CodeIgniter\Model;
+
+class FootballLeagues extends Model
+{
+    protected $table            = 'football_leagues';
+    protected $primaryKey       = 'id';
+    protected $returnType       = 'array';
+    protected $useSoftDeletes   = false;
+    protected $protectFields    = true;
+    protected $allowedFields = ['id', 'name', 'type'];
+
+    protected bool $allowEmptyInserts = false;
+    protected bool $updateOnlyChanged = true;
+
+    protected array $casts = [];
+    protected array $castHandlers = [];
+
+    // Dates
+    protected $useTimestamps = false;
+    protected $dateFormat    = 'datetime';
+    protected $createdField  = 'created_at';
+    protected $updatedField  = 'updated_at';
+    protected $deletedField  = 'deleted_at';
+
+    // Validation
+    protected $validationRules      = [];
+    protected $validationMessages   = [];
+    protected $skipValidation       = false;
+    protected $cleanValidationRules = true;
+
+    // Callbacks
+    protected $allowCallbacks = true;
+    protected $beforeInsert   = [];
+    protected $afterInsert    = [];
+    protected $beforeUpdate   = [];
+    protected $afterUpdate    = [];
+    protected $beforeFind     = [];
+    protected $afterFind      = [];
+    protected $beforeDelete   = [];
+    protected $afterDelete    = [];
+
+
+
+}

--- a/app/Repositories/FootballApisRepository.php
+++ b/app/Repositories/FootballApisRepository.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Repositories;
+
+use CodeIgniter\HTTP\CURLRequest;
+
+class FootballApisRepository
+{
+    protected CURLRequest $client;
+
+    public function __construct()
+    {
+        // Example: football-data.org or any API of your choice
+        $this->client = \Config\Services::curlrequest([
+            'baseURI' => 'https://v3.football.api-sports.io/',
+            'timeout' => 15,
+            'headers' => [
+                'x-rapidapi-key' => 'c15a535ee6cc78ff90a029200bea93ff',    // Store your key in .env
+            ],
+        ]);
+
+    }
+
+    /** Get all leagues */
+    public function getLeagues(): array
+    {
+        $response = $this->client->get('leagues');
+        $data = json_decode($response->getBody(), true);
+        $leagues = $data['response'] ?? [];
+        return $leagues;
+    }
+
+    /** Get fixtures / matches by league */
+    public function getFixtures(int $leagueId): array
+    {
+        $response = $this->client->get("competitions/{$leagueId}/matches");
+        return json_decode($response->getBody(), true);
+    }
+
+    /** Get odds (example endpoint, depends on provider) */
+    public function getOdds(int $matchId): array
+    {
+        $response = $this->client->get("matches/{$matchId}/odds");
+        return json_decode($response->getBody(), true);
+    }
+
+    /** Get team statistics */
+    public function getTeamStats(int $teamId): array
+    {
+        $response = $this->client->get("teams/{$teamId}");
+        return json_decode($response->getBody(), true);
+    }
+}

--- a/app/Services/FootballService.php
+++ b/app/Services/FootballService.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Services;
+
+use App\Repositories\FootballApisRepository;
+
+class FootballService
+{
+    protected FootballApisRepository $repository;
+
+    public function __construct()
+    {
+        $this->repository = new FootballApisRepository();
+    }
+
+    public function listLeagues(): array
+    {
+        return $this->repository->getLeagues();
+    }
+}

--- a/app/Views/home.php
+++ b/app/Views/home.php
@@ -7,40 +7,6 @@
     </div>
 </div>
 
-<div id="wg-api-basketball-games"
-     data-host="v1.basketball.api-sports.io"
-     data-key="6ec045f3eb893d762e6f9a10fd6bf3a7"
-     data-date=""
-     data-league=""
-     data-season="2022-2023"
-     data-theme=""
-     data-refresh="15"
-     data-show-toolbar="true"
-     data-show-errors="false"
-     data-show-logos="false"
-     data-modal-game="true"
-     data-modal-standings="true"
-     data-modal-show-logos="true">
-</div>
-<script
-        type="module"
-        src="https://widgets.api-sports.io/2.0.3/widgets.js">
-</script>
-
-<div id="wg-api-football-game"
-     data-host="v3.football.api-sports.io"
-     data-key="6ec045f3eb893d762e6f9a10fd6bf3a7"
-     data-id="718243"
-     data-theme=""
-     data-refresh="15"
-     data-show-errors="false"
-     data-show-logos="true">
-</div>
-<script
-        type="module"
-        src="https://widgets.api-sports.io/2.0.3/widgets.js">
-</script>
-
 
 <div class="card">
     <div class="card-header">


### PR DESCRIPTION
This PR implements storing football leagues retrieved from the external API.
We use Factory Pattern , services and command to store data to database from external api.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a public endpoint to list football leagues, returning live data.
- Style
  - Removed embedded basketball and football widgets from the home page for a cleaner, faster experience.
- Chores
  - Introduced background integration with a football API for leagues data.
  - Added database migration and model to store leagues.
  - Added a CLI command to import leagues into the database.
  - Included a sample leagues API response fixture for development/testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->