### PR TITLE
Implement Foodball Teams Feauture

### DIFF
--- a/app/Commands/StoreFootballTeams.php
+++ b/app/Commands/StoreFootballTeams.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace App\Commands;
+
+use App\Models\FootballLeagues;
+use App\Models\FootballTeams;
+use App\Services\FootballService;
+use CodeIgniter\CLI\BaseCommand;
+use CodeIgniter\CLI\CLI;
+
+class StoreFootballTeams extends BaseCommand
+{
+    /**
+     * The Command's Group
+     *
+     * @var string
+     */
+    protected $group = "App";
+
+    /**
+     * The Command's Name
+     *
+     * @var string
+     */
+    protected $name = "app:store_football_teams";
+
+    /**
+     * The Command's Description
+     *
+     * @var string
+     */
+    protected $description = "This command stores football teams in the database.";
+
+    /**
+     * The Command's Usage
+     *
+     * @var string
+     */
+    protected $usage = "app:store_football_teams";
+
+    /**
+     * The Command's Arguments
+     *
+     * @var array
+     */
+    protected $arguments = [];
+
+    /**
+     * The Command's Options
+     *
+     * @var array
+     */
+    protected $options = [];
+
+    protected FootballService $service;
+    protected FootballLeagues $leagueModel;
+    protected FootballTeams $teamModel;
+
+    public function __construct()
+    {
+        $this->service = new FootballService();
+        $this->leagueModel = new \App\Models\FootballLeagues();
+        $this->teamModel = new \App\Models\FootballTeams();
+    }
+
+    /**
+     * Actually execute a command.
+     *
+     * @param array $params
+     */
+    public function run(array $params)
+    {
+        $season = "2023";
+        // Fetch all leagues (assuming 'id' is your primary key)
+        $leagueIds = $this->leagueModel->findColumn("id");
+        $inserted = $skipped = $failed = 0;
+
+        foreach ($leagueIds as $id) {
+            $leagueId = $id;
+
+            // Fetch teams for this league and season, e.g., 2023
+            $league_teams = $this->service->listTeams($leagueId, $season);
+            foreach ($league_teams as $team) {
+                $teamId = $team["team"]["id"];
+
+                // Check if the team already exists
+                if ($this->teamModel->find($teamId)) {
+                    $skipped++;
+                    continue; // Skip insertion if the team already exists
+                }
+
+                $teamModel = $this->teamModel;
+
+                $data = [
+                    "id" => $team["team"]["id"],
+                    "name" => $team["team"]["name"],
+                    "code" => $team["team"]["code"] ?? "Unknown",
+                    "country" => $team["team"]["country"] ?? "Unknown",
+                    "founded" => $team["team"]["founded"] ?? 0,
+                    "national" => $team["team"]["national"], // or true if it's a national team
+                    "venue_id" => $team["venue"]["id"], // Replace with an actual venue_id from your venues table
+                    "league_id" => $leagueId,
+                ];
+
+                try {
+                    $teamModel->insert($data);
+                    $inserted = ($inserted ?? 0) + 1;
+                } catch (\Exception $e) {
+                    $failed = ($failed ?? 0) + 1;
+                    CLI::error(
+                        "Insert failed for league " .
+                        $team["team"]["id"] .
+                        ": " .
+                        $e->getMessage()
+                    );
+                }
+            }
+
+            // Handle $response as needed (e.g., store, log, process)
+        }
+        echo "Leagues stored successfully.";
+        echo "Inserted: {$inserted}, skipped: {$skipped}, failed: {$failed}";
+    }
+}

--- a/app/Database/Migrations/2025-08-31-151908_CreateFootabllTeamsTable.php
+++ b/app/Database/Migrations/2025-08-31-151908_CreateFootabllTeamsTable.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Database\Migrations;
+
+use CodeIgniter\Database\Migration;
+
+class CreateFootabllTeamsTable extends Migration
+{
+    public function up()
+    {
+        $this->forge->addField([
+            'id'        => [
+                'type'           => 'INT',
+                'constraint'     => 11,
+                'unsigned'       => true,
+                'null'           => false,
+                'auto_increment' => false, // Not auto increment
+            ],
+            'name'      => [
+                'type'           => 'VARCHAR',
+                'constraint'     => '255',
+                'null'           => false,
+            ],
+            'code'      => [
+                'type'           => 'VARCHAR',
+                'constraint'     => '10',
+                'null'           => true,
+            ],
+            'country'   => [
+                'type'           => 'VARCHAR',
+                'constraint'     => '100',
+                'null'           => true,
+            ],
+            'founded'   => [
+                'type'           => 'SMALLINT',
+                'constraint'     => 4,
+                'null'           => true,
+            ],
+            'national'  => [
+                'type'           => 'BOOLEAN',
+                'null'           => true,
+                'default'        => false,
+            ],
+            'venue_id'  => [
+                'type'           => 'INT',
+                'constraint'     => 11,
+                'unsigned'       => true,
+                'null'           => true,
+            ],
+            'league_id'  => [
+                'type'           => 'INT',
+                'constraint'     => 11,
+                'unsigned'       => true,
+                'null'           => true,
+            ],
+        ]);
+
+        $this->forge->addKey('id', true); // Primary key
+        $this->forge->createTable('football_teams');
+    }
+
+    public function down()
+    {
+        $this->forge->dropTable('football_teams');
+    }
+}

--- a/app/Models/FootballTeams.php
+++ b/app/Models/FootballTeams.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Models;
+
+use CodeIgniter\Model;
+
+class FootballTeams extends Model
+{
+    protected $table            = 'football_teams';
+    protected $primaryKey       = 'id';
+    protected $returnType       = 'array';
+    protected $useSoftDeletes   = false;
+    protected $protectFields    = true;
+    protected $allowedFields    = [
+        'id',
+        'name',
+        'code',
+        'country',
+        'founded',
+        'national',
+        'venue_id',
+        'league_id'
+    ];
+
+    protected bool $allowEmptyInserts = false;
+    protected bool $updateOnlyChanged = true;
+
+    protected array $casts = [];
+    protected array $castHandlers = [];
+
+    // Dates
+    protected $useTimestamps = false;
+    protected $dateFormat    = 'datetime';
+    protected $createdField  = 'created_at';
+    protected $updatedField  = 'updated_at';
+    protected $deletedField  = 'deleted_at';
+
+    // Validation
+    protected $validationRules      = [];
+    protected $validationMessages   = [];
+    protected $skipValidation       = false;
+    protected $cleanValidationRules = true;
+
+
+}

--- a/app/Repositories/FootballApisRepository.php
+++ b/app/Repositories/FootballApisRepository.php
@@ -30,6 +30,21 @@ class FootballApisRepository
         return $leagues;
     }
 
+    /** Get All Teams */
+    //Using leagueId and Session
+    public function getTeams(int $leagueId, string $session){
+        $response = $this->client->get('teams', [
+            'query' => [
+                'league' => $leagueId,
+                'season' => $session,
+            ],
+            'timeout' => 30,
+        ]);
+        $data = json_decode($response->getBody(), true);
+        $teams = $data['response'] ?? [];
+        return $teams;
+    }
+
     /** Get fixtures / matches by league */
     public function getFixtures(int $leagueId): array
     {

--- a/app/Services/FootballService.php
+++ b/app/Services/FootballService.php
@@ -17,4 +17,9 @@ class FootballService
     {
         return $this->repository->getLeagues();
     }
+
+    public function listTeams($leagueId, $season): array
+    {
+        return $this->repository->getTeams($leagueId, $season);
+    }
 }


### PR DESCRIPTION
Create Functionality to store teams based on Season and LeagueId

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a CLI command to fetch and store football teams by league for the 2023 season.
  - Skips already stored teams and reports a summary of inserted, skipped, and failed records.
  - Provides clearer error output for any insert failures.

- Chores
  - Introduced a database table to persist football team data.
  - Added a data model and service integration to support team retrieval and storage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->